### PR TITLE
Iteration 3

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -51,6 +51,17 @@ class LinkedList
     end
   end
 
+  def insert(index, data)
+    if index > count
+      append(data)
+    else
+      new_node = Node.new(data)
+      new_node.set_next(find_node(index))
+      previous_node = find_node(index - 1)
+      previous_node.set_next(new_node)
+    end
+  end
+
   private
 
   def last_node
@@ -58,6 +69,18 @@ class LinkedList
       current_node = @head
       until current_node.next_node == nil
         current_node = current_node.next_node
+      end
+    end
+    current_node
+  end
+
+  def find_node(index)
+    if @head != nil
+      current_node = @head
+      node_index = 0
+      until node_index == index
+        current_node = current_node.next_node
+        node_index += 1
       end
     end
     current_node

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -41,6 +41,16 @@ class LinkedList
     string
   end
 
+  def prepend(data)
+    if @head == nil
+      @head = Node.new(data)
+    else
+      new_head = Node.new(data)
+      new_head.set_next(@head)
+      @head = new_head
+    end
+  end
+
   private
 
   def last_node

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -45,4 +45,26 @@ describe 'Linked List' do
 
     expect(@list.to_string).to eq("boom bap")
   end
+
+  it 'can prepend a sound to the list' do
+    @list.append("boom")
+    @list.append("bap")
+    @list.prepend("tss")
+
+    expect(@list.head.data).to eq("tss")
+
+    expect(@list.to_string).to eq("tss boom bap")
+
+    expect(@list.count).to eq(3)
+  end
+
+  it 'can prepend an empty list' do
+    @list.prepend("tss")
+
+    expect(@list.head.data).to eq("tss")
+
+    expect(@list.to_string).to eq("tss")
+
+    expect(@list.count).to eq(1)
+  end
 end

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -67,4 +67,17 @@ describe 'Linked List' do
 
     expect(@list.count).to eq(1)
   end
+
+  it 'can insert a sound into a position' do
+    @list.append("boom")
+    @list.append("bap")
+    @list.prepend("tss")
+    @list.insert(1, "boom")
+
+    expect(@list.head.data).to eq("tss")
+
+    expect(@list.to_string).to eq("tss boom boom bap")
+
+    expect(@list.count).to eq(4)
+  end
 end


### PR DESCRIPTION
This PR brings in the functionality of a Prepend and Insert method for the Linked List. Prepend will put a new Node as the new Head, moving all other Nodes down the index by one. Insert will take a new Node, and place it into the index determined. This method required a private method in Find Node, that will take an index, and find the Node at that index of the List.