### PR TITLE
Iteration 5

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -3,8 +3,13 @@ require './lib/linked_list'
 
 class JungleBeat
   attr_reader :list
-  
+
   def initialize
     @list = LinkedList.new
+  end
+
+  def append(sounds)
+    split_sounds = sounds.split(" ")
+    split_sounds.each {|sound| @list.append(sound)}
   end
 end

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -12,4 +12,8 @@ class JungleBeat
     split_sounds = sounds.split(" ")
     split_sounds.each {|sound| @list.append(sound)}
   end
+
+  def count
+    @list.count
+  end
 end

--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,0 +1,10 @@
+require './lib/node'
+require './lib/linked_list'
+
+class JungleBeat
+  attr_reader :list
+  
+  def initialize
+    @list = LinkedList.new
+  end
+end

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require './lib/jungle_beat'
+
+describe 'Jungle Beat' do
+  before :each do
+    @jungle_beat = JungleBeat.new
+  end
+
+  it 'has a list with no head' do
+    expect(@jungle_beat.list).to_not eq(nil)
+    expect(@jungle_beat.list.head).to eq(nil)
+  end
+end

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -15,7 +15,7 @@ describe 'Jungle Beat' do
     @jungle_beat.append("boom bam bip")
 
     expect(@jungle_beat.list.head.data).to eq("boom")
-    expect(@jungle_beat.list.next_node.data).to eq("bam")
+    expect(@jungle_beat.list.head.next_node.data).to eq("bam")
     expect(@jungle_beat.count).to eq(3)
   end
 end

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -10,4 +10,12 @@ describe 'Jungle Beat' do
     expect(@jungle_beat.list).to_not eq(nil)
     expect(@jungle_beat.list.head).to eq(nil)
   end
+
+  it 'can append multiple sounds' do
+    @jungle_beat.append("boom bam bip")
+
+    expect(@jungle_beat.list.head.data).to eq("boom")
+    expect(@jungle_beat.list.next_node.data).to eq("bam")
+    expect(@jungle_beat.count).to eq(3)
+  end
 end


### PR DESCRIPTION
This PR brings in the functionality of the Jungle Beat wrapper around a Linked List. The Wrapper can provide extra functionality, like being able to Append multiple sounds at a time.
This will take a string of space separated sounds, and append them individually to the Linked List contained. 
The Jungle Beat wrapper can also return a Count of Nodes in the Linked List.